### PR TITLE
Feature/allow no dns scrapes

### DIFF
--- a/389ds_exporter.go
+++ b/389ds_exporter.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	interval    = flag.Duration("interval", 60*time.Second, "Scrape interval")
+	ipaDns      = flag.Bool("ipa-dns", true, "Should we scrape dns stats?")
 	ipaDomain   = flag.String("ipa-domain", "", "FreeIPA domain e.g. example.org")
 	ldapAddr    = flag.String("ldap.addr", "localhost:389", "Address of 389ds server")
 	ldapUser    = flag.String("ldap.user", "cn=Directory Manager", "389ds Directory Manager user")
@@ -61,7 +62,7 @@ func main() {
 	log.Info("Starting 389ds scraper for ", *ldapAddr)
 	for range time.Tick(*interval) {
 		log.Debug("Starting metrics scrape")
-		exporter.ScrapeMetrics(*ldapAddr, *ldapUser, *ldapPass, *ipaDomain)
+		exporter.ScrapeMetrics(*ldapAddr, *ldapUser, *ldapPass, *ipaDomain, *ipaDns)
 	}
 }
 

--- a/389ds_exporter.go
+++ b/389ds_exporter.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	interval    = flag.Duration("interval", 60*time.Second, "Scrape interval")
-	ipaDns      = flag.Bool("ipa-dns", true, "Should we scrape dns stats?")
+	ipaDns      = flag.Bool("ipa-dns", true, "Should we scrape DNS stats?")
 	ipaDomain   = flag.String("ipa-domain", "", "FreeIPA domain e.g. example.org")
 	ldapAddr    = flag.String("ldap.addr", "localhost:389", "Address of 389ds server")
 	ldapUser    = flag.String("ldap.user", "cn=Directory Manager", "389ds Directory Manager user")

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To run:
 ```
 
 * __`-interval`:__ Scrape interval (default 1m0s)
+* __`-ipa-dns`:__ Should we scrape DNS stats? (default true)
 * __`-ipa-domain`:__ FreeIPA domain e.g. example.org
 * __`-ldap.addr`:__ Address of 389ds server (default "localhost:389")
 * __`-ldap.pass`:__ 389ds Directory Manager password


### PR DESCRIPTION
Allow skipping of DNS scrapes via command line flag -ipa-dns (e.g. `-ipa-dns=false`).  Not all FreeIPA installations have DNS and having a flag to control this will avoid `LDAP Result Code 32 "No Such Object"` errors.